### PR TITLE
Added automatic changelog creation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v2.1.0, etc.
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref }}  # Use the tag as the release name
+          body: ${{ steps.changelog.outputs.changelog }}  # Attach changelog


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of GitHub releases and changelogs. The most important changes include setting up the workflow to trigger on version tags, configuring Git, generating a changelog, and creating the release.

### Workflow Automation:

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33): Added a new workflow named "Release" that triggers on version tags like `v1.0.0`, `v2.1.0`, etc.
* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33): Configured Git with a global user name and email for the GitHub Actions runner.
* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33): Integrated `mikepenz/release-changelog-builder-action` to generate a changelog.
* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33): Utilized `softprops/action-gh-release` to create a GitHub release with the tag name and generated changelog.