### PR TITLE
Fixed release name shown as git reference

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref }}  # Use the tag as the release name
+          name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}  # Attach changelog


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/changelog.yml` file. The change updates the naming convention for GitHub releases.

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85L32-R32): Modified the `name` attribute in the `Create GitHub Release` step to use a more descriptive format by including the word "Release" before the tag name.