### PR TITLE
Upgraded the Go version from 1.22 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/enthus-golang/lenovo
 
-go 1.22
+go 1.24
 
 require golang.org/x/net v0.35.0


### PR DESCRIPTION
This pull request updates the Go module configuration for the `github.com/enthus-golang/lenovo` project. The most important change is the upgrade of the Go version used in the project.

Go module configuration updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Upgraded the Go version from `1.22` to `1.24`, aligning the project with the latest features and improvements in the Go language.