### PR TITLE
feat: add warranty details, contract, and warranty option endpoints

### DIFF
--- a/contract.go
+++ b/contract.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 )
 
-const contractURL = baseURL + "/Contract"
-
 // Contract represents a Lenovo service contract and the products it covers.
 type Contract struct {
 	ID          string
@@ -35,7 +33,7 @@ type ContractProduct struct {
 //
 // See https://supportapi.lenovo.com/documentation/Warranty.html
 func (c *Client) ContractByID(id string) (*Contract, error) {
-	r, err := http.NewRequest(http.MethodGet, contractURL+"/"+url.PathEscape(id), nil)
+	r, err := http.NewRequest(http.MethodGet, c.baseURL+"/Contract/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/contract.go
+++ b/contract.go
@@ -46,7 +46,7 @@ func (c *Client) ContractByID(id string) (*Contract, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}

--- a/contract.go
+++ b/contract.go
@@ -1,0 +1,62 @@
+package lenovo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const contractURL = baseURL + "/Contract"
+
+// Contract represents a Lenovo service contract and the products it covers.
+type Contract struct {
+	ID          string
+	Description string
+	Start       Time
+	End         Time
+	Products    []ContractProduct
+}
+
+// ContractProduct is a single product covered by a Contract.
+type ContractProduct struct {
+	Serial          string
+	MachineType     string
+	Name            string
+	Quantity        int
+	ItemNumber      string
+	ChargeCode      string
+	SLA             string
+	EntitlementCode string
+	Status          string
+	Start           Time
+	End             Time
+}
+
+// ContractByID looks up the details of a service contract by its ID.
+//
+// See https://supportapi.lenovo.com/documentation/Warranty.html
+func (c *Client) ContractByID(id string) (*Contract, error) {
+	r, err := http.NewRequest(http.MethodGet, contractURL+"/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.sendRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+	if resp.ContentLength == 2 {
+		return nil, ErrInvalidResponse
+	}
+
+	var contract Contract
+	if err := json.NewDecoder(resp.Body).Decode(&contract); err != nil {
+		return nil, err
+	}
+	return &contract, nil
+}

--- a/contract.go
+++ b/contract.go
@@ -1,8 +1,6 @@
 package lenovo
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -42,21 +40,12 @@ func (c *Client) ContractByID(id string) (*Contract, error) {
 		return nil, err
 	}
 
-	resp, err := c.sendRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
-	}
-	if resp.ContentLength == 2 {
-		return nil, ErrInvalidResponse
-	}
-
 	var contract Contract
-	if err := json.NewDecoder(resp.Body).Decode(&contract); err != nil {
+	if err := c.do(r, &contract); err != nil {
 		return nil, err
+	}
+	if contract.ID == "" {
+		return nil, ErrInvalidResponse
 	}
 	return &contract, nil
 }

--- a/contract_test.go
+++ b/contract_test.go
@@ -1,0 +1,87 @@
+package lenovo
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestContractByID(t *testing.T) {
+	const body = `{
+		"ID": "CT-001", "Description": "Premier",
+		"Start": "2024-01-01T00:00:00Z", "End": "2027-01-01T00:00:00Z",
+		"Products": [{
+			"Serial": "MP1ABCDE", "MachineType": "20HE", "Name": "ThinkPad",
+			"Quantity": 1, "Status": "ACTIVE",
+			"Start": "2024-01-01T00:00:00Z", "End": "2027-01-01T00:00:00Z"
+		}]
+	}`
+
+	var seen http.Request
+	srv := newTestServer(t, respondJSON(&seen, body))
+	c := newTestClient(t, srv)
+
+	got, err := c.ContractByID("CT-001")
+	if err != nil {
+		t.Fatalf("ContractByID: %v", err)
+	}
+	if seen.Method != http.MethodGet {
+		t.Errorf("method = %q, want GET", seen.Method)
+	}
+	if seen.URL.Path != "/Contract/CT-001" {
+		t.Errorf("path = %q, want /Contract/CT-001", seen.URL.Path)
+	}
+	want := &Contract{
+		ID: "CT-001", Description: "Premier",
+		Start: Time{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		End:   Time{time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)},
+		Products: []ContractProduct{{
+			Serial: "MP1ABCDE", MachineType: "20HE", Name: "ThinkPad",
+			Quantity: 1, Status: "ACTIVE",
+			Start: Time{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			End:   Time{time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)},
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Contract mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestContractByID_Errors(t *testing.T) {
+	t.Run("non-200 returns ErrRequestFailed", func(t *testing.T) {
+		srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusNotFound)
+		})
+		c := newTestClient(t, srv)
+		if _, err := c.ContractByID("X"); !errors.Is(err, ErrRequestFailed) {
+			t.Errorf("err = %v, want ErrRequestFailed", err)
+		}
+	})
+
+	t.Run("empty body returns ErrInvalidResponse", func(t *testing.T) {
+		srv := newTestServer(t, respondJSON(nil, `{}`))
+		c := newTestClient(t, srv)
+		if _, err := c.ContractByID("X"); !errors.Is(err, ErrInvalidResponse) {
+			t.Errorf("err = %v, want ErrInvalidResponse", err)
+		}
+	})
+}
+
+func TestContractByID_EscapesPath(t *testing.T) {
+	var rawPath string
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		rawPath = r.URL.EscapedPath()
+		_, _ = io.WriteString(w, `{"ID":"CT/01"}`)
+	})
+	c := newTestClient(t, srv)
+
+	if _, err := c.ContractByID("CT/01"); err != nil {
+		t.Fatalf("ContractByID: %v", err)
+	}
+	if want := "/Contract/CT%2F01"; rawPath != want {
+		t.Errorf("escaped path = %q, want %q", rawPath, want)
+	}
+}

--- a/lenovo.go
+++ b/lenovo.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/cookiejar"
+	"strings"
 
 	"golang.org/x/net/publicsuffix"
 )
+
+const defaultBaseURL = "https://supportapi.lenovo.com/v2.5"
 
 var (
 	ErrNoClientID = errors.New("no ClientID set")
@@ -15,14 +18,16 @@ var (
 type ClientOptionFunc func(*Client) error
 
 type Client struct {
-	c  *http.Client
-	id string
+	c       *http.Client
+	id      string
+	baseURL string
 }
 
 // NewClient creates a new client to work with Lenovo eSupport.
 func NewClient(options ...ClientOptionFunc) (*Client, error) {
 	c := &Client{
-		c: http.DefaultClient,
+		c:       http.DefaultClient,
+		baseURL: defaultBaseURL,
 	}
 
 	// Run the options on it
@@ -54,6 +59,16 @@ func SetHttpClient(httpClient *http.Client) ClientOptionFunc {
 		} else {
 			c.c = http.DefaultClient
 		}
+		return nil
+	}
+}
+
+// SetBaseURL overrides the default Lenovo eSupport base URL. The default is
+// https://supportapi.lenovo.com/v2.5. Useful for tests against an httptest
+// server.
+func SetBaseURL(u string) ClientOptionFunc {
+	return func(c *Client) error {
+		c.baseURL = strings.TrimRight(u, "/")
 		return nil
 	}
 }

--- a/lenovo_test.go
+++ b/lenovo_test.go
@@ -1,0 +1,47 @@
+package lenovo
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestServer spins up an httptest.Server and registers t.Cleanup to shut
+// it down.
+func newTestServer(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestClient builds a Client pointed at srv.
+func newTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	c, err := NewClient(
+		SetClientID("test-client-id"),
+		SetHttpClient(srv.Client()),
+		SetBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+// respondJSON returns a handler that parses the form, optionally records the
+// request into seen, and writes body as JSON.
+func respondJSON(seen *http.Request, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if seen != nil {
+			*seen = *r
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}
+}

--- a/warranty.go
+++ b/warranty.go
@@ -179,7 +179,7 @@ func (c *Client) WarrantyDetailsByID(id string) (*WarrantyDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}
@@ -245,7 +245,7 @@ func (c *Client) warrantyOptions(countryCode, key, value string) ([]WarrantyOpti
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}

--- a/warranty.go
+++ b/warranty.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	baseURL     = "https://supportapi.lenovo.com/v2.5"
-	warrantyURL = baseURL + "/warranty"
-
 	InvalidCountry = "**INVALID**"
 
 	contentTypeForm = "application/x-www-form-urlencoded"
@@ -103,7 +100,7 @@ func (c *Client) WarrantyBySerial(serial string) (*Warranty, error) {
 	data := url.Values{}
 	data.Set("Serial", serial)
 
-	r, err := newFormRequest(http.MethodPost, warrantyURL, data)
+	r, err := newFormRequest(http.MethodPost, c.baseURL+"/warranty", data)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +126,7 @@ func (c *Client) WarrantiesBySerials(serials []string) ([]Warranty, error) {
 		data.Add("Serial", v)
 	}
 
-	r, err := newFormRequest(http.MethodPost, warrantyURL, data)
+	r, err := newFormRequest(http.MethodPost, c.baseURL+"/warranty", data)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +142,7 @@ func (c *Client) WarrantiesBySerials(serials []string) ([]Warranty, error) {
 //
 // See https://supportapi.lenovo.com/documentation/Warranty.html
 func (c *Client) WarrantyDetailsByID(id string) (*WarrantyDetails, error) {
-	r, err := http.NewRequest(http.MethodGet, warrantyURL+"/"+url.PathEscape(id), nil)
+	r, err := http.NewRequest(http.MethodGet, c.baseURL+"/warranty"+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +188,7 @@ func (c *Client) WarrantyOptionsByProduct(countryCode, product string) ([]Warran
 }
 
 func (c *Client) warrantyOptions(countryCode, key, value string) ([]WarrantyOption, error) {
-	u := baseURL + "/warrantyoption"
+	u := c.baseURL + "/warrantyoption"
 	if countryCode != "" {
 		u += "/" + url.PathEscape(countryCode)
 	}

--- a/warranty.go
+++ b/warranty.go
@@ -11,9 +11,39 @@ import (
 )
 
 const (
-	warrantyURL = "https://supportapi.lenovo.com/v2.5/warranty"
+	baseURL     = "https://supportapi.lenovo.com/v2.5"
+	warrantyURL = baseURL + "/warranty"
 
 	InvalidCountry = "**INVALID**"
+)
+
+// WarrantyType values returned by the Warranty Details endpoint.
+const (
+	WarrantyTypeBase     = "BASE"
+	WarrantyTypeUpgrade  = "UPGRADE"
+	WarrantyTypeExtended = "EXTENDED"
+	WarrantyTypeInstant  = "INSTANT"
+	WarrantyTypeUnknown  = "UNKNOWN"
+)
+
+// WarrantyDelivery values returned by the Warranty Details endpoint.
+const (
+	DeliveryBringIn     = "BRING_IN"
+	DeliveryCourier     = "COURIER"
+	DeliveryCRU         = "CRU"
+	DeliveryDepot       = "DEPOT"
+	DeliveryAdvExchange = "ADV_EXCHANGE"
+	DeliveryOnSite      = "ON_SITE"
+	DeliveryPartsOnly   = "PARTS_ONLY"
+	DeliveryTechSupport = "TECH_SUPPORT"
+	DeliveryUnknown     = "UNKNOWN"
+)
+
+// WarrantyCategory values returned by the Warranty Details endpoint.
+const (
+	CategoryMachine   = "MACHINE"
+	CategoryComponent = "COMPONENT"
+	CategoryUnknown   = "UNKNOWN"
 )
 
 var (
@@ -55,6 +85,17 @@ type WarrantyContract struct {
 	Status          string
 	Start           Time
 	End             Time
+}
+
+// WarrantyDetails describes a warranty offering identified by its SDF code.
+type WarrantyDetails struct {
+	ID          string
+	Name        string
+	Description string
+	Type        string
+	Delivery    string
+	Category    string
+	Duration    string
 }
 
 func (c *Client) WarrantyBySerial(serial string) (*Warranty, error) {
@@ -123,4 +164,95 @@ func (c *Client) WarrantiesBySerials(serials []string) ([]Warranty, error) {
 	}
 
 	return w, nil
+}
+
+// WarrantyDetailsByID looks up a warranty offering by its SDF code.
+//
+// See https://supportapi.lenovo.com/documentation/Warranty.html
+func (c *Client) WarrantyDetailsByID(id string) (*WarrantyDetails, error) {
+	r, err := http.NewRequest(http.MethodGet, warrantyURL+"/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.sendRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+	if resp.ContentLength == 2 {
+		return nil, ErrInvalidResponse
+	}
+
+	var w WarrantyDetails
+	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+		return nil, err
+	}
+	return &w, nil
+}
+
+// WarrantyOption represents a single international warranty option for a
+// destination country.
+type WarrantyOption struct {
+	ID          string
+	Name        string
+	Description string
+	Type        string
+	Delivery    string
+	Category    string
+	Duration    string
+	Country     string
+}
+
+// WarrantyOptionsBySerial returns the international warranty options for the
+// given serial number. countryCode may be empty to use the API default.
+//
+// See https://supportapi.lenovo.com/documentation/Warranty.html
+func (c *Client) WarrantyOptionsBySerial(countryCode, serial string) ([]WarrantyOption, error) {
+	return c.warrantyOptions(countryCode, "Serial", serial)
+}
+
+// WarrantyOptionsByProduct returns the international warranty options for the
+// given product (catalog identifier). countryCode may be empty to use the API
+// default.
+//
+// See https://supportapi.lenovo.com/documentation/Warranty.html
+func (c *Client) WarrantyOptionsByProduct(countryCode, product string) ([]WarrantyOption, error) {
+	return c.warrantyOptions(countryCode, "Product", product)
+}
+
+func (c *Client) warrantyOptions(countryCode, key, value string) ([]WarrantyOption, error) {
+	u := baseURL + "/warrantyoption"
+	if countryCode != "" {
+		u += "/" + url.PathEscape(countryCode)
+	}
+
+	data := url.Values{}
+	data.Set(key, value)
+	dataEncoded := data.Encode()
+
+	r, err := http.NewRequest(http.MethodPost, u, strings.NewReader(dataEncoded))
+	if err != nil {
+		return nil, err
+	}
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Add("Content-Length", strconv.Itoa(len(dataEncoded)))
+
+	resp, err := c.sendRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+
+	var opts []WarrantyOption
+	if err := json.NewDecoder(resp.Body).Decode(&opts); err != nil {
+		return nil, err
+	}
+	return opts, nil
 }

--- a/warranty.go
+++ b/warranty.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
@@ -15,6 +14,8 @@ const (
 	warrantyURL = baseURL + "/warranty"
 
 	InvalidCountry = "**INVALID**"
+
+	contentTypeForm = "application/x-www-form-urlencoded"
 )
 
 // WarrantyType values returned by the Warranty Details endpoint.
@@ -102,31 +103,18 @@ func (c *Client) WarrantyBySerial(serial string) (*Warranty, error) {
 	data := url.Values{}
 	data.Set("Serial", serial)
 
-	dataEncoded := data.Encode()
-	r, err := http.NewRequest(http.MethodPost, warrantyURL, strings.NewReader(dataEncoded))
+	r, err := newFormRequest(http.MethodPost, warrantyURL, data)
 	if err != nil {
 		return nil, err
-	}
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	r.Header.Add("Content-Length", strconv.Itoa(len(dataEncoded)))
-
-	resp, err := c.sendRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
-	}
-	if resp.ContentLength == 2 {
-		return nil, ErrInvalidResponse
 	}
 
 	var w Warranty
-	err = json.NewDecoder(resp.Body).Decode(&w)
-	if err != nil {
+	if err := c.do(r, &w); err != nil {
 		return nil, err
 	}
-
+	if w.Serial == "" {
+		return nil, ErrInvalidResponse
+	}
 	return &w, nil
 }
 
@@ -141,28 +129,15 @@ func (c *Client) WarrantiesBySerials(serials []string) ([]Warranty, error) {
 		data.Add("Serial", v)
 	}
 
-	dataEncoded := data.Encode()
-	r, err := http.NewRequest(http.MethodPost, warrantyURL, strings.NewReader(dataEncoded))
+	r, err := newFormRequest(http.MethodPost, warrantyURL, data)
 	if err != nil {
 		return nil, err
-	}
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	r.Header.Add("Content-Length", strconv.Itoa(len(dataEncoded)))
-
-	resp, err := c.sendRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}
 
 	var w []Warranty
-	err = json.NewDecoder(resp.Body).Decode(&w)
-	if err != nil {
+	if err := c.do(r, &w); err != nil {
 		return nil, err
 	}
-
 	return w, nil
 }
 
@@ -175,21 +150,12 @@ func (c *Client) WarrantyDetailsByID(id string) (*WarrantyDetails, error) {
 		return nil, err
 	}
 
-	resp, err := c.sendRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
-	}
-	if resp.ContentLength == 2 {
-		return nil, ErrInvalidResponse
-	}
-
 	var w WarrantyDetails
-	if err := json.NewDecoder(resp.Body).Decode(&w); err != nil {
+	if err := c.do(r, &w); err != nil {
 		return nil, err
+	}
+	if w.ID == "" {
+		return nil, ErrInvalidResponse
 	}
 	return &w, nil
 }
@@ -232,27 +198,40 @@ func (c *Client) warrantyOptions(countryCode, key, value string) ([]WarrantyOpti
 
 	data := url.Values{}
 	data.Set(key, value)
-	dataEncoded := data.Encode()
 
-	r, err := http.NewRequest(http.MethodPost, u, strings.NewReader(dataEncoded))
+	r, err := newFormRequest(http.MethodPost, u, data)
 	if err != nil {
 		return nil, err
-	}
-	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	r.Header.Add("Content-Length", strconv.Itoa(len(dataEncoded)))
-
-	resp, err := c.sendRequest(r)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}
 
 	var opts []WarrantyOption
-	if err := json.NewDecoder(resp.Body).Decode(&opts); err != nil {
+	if err := c.do(r, &opts); err != nil {
 		return nil, err
 	}
 	return opts, nil
+}
+
+// newFormRequest builds an HTTP request with a form-encoded body. The Go HTTP
+// client computes the Content-Length automatically from the *strings.Reader.
+func newFormRequest(method, endpoint string, data url.Values) (*http.Request, error) {
+	r, err := http.NewRequest(method, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	r.Header.Set("Content-Type", contentTypeForm)
+	return r, nil
+}
+
+// do sends the request, asserts a 2xx response, and decodes the body into v.
+func (c *Client) do(r *http.Request, v any) error {
+	resp, err := c.sendRequest(r)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(v)
 }

--- a/warranty_test.go
+++ b/warranty_test.go
@@ -92,7 +92,7 @@ func TestWarrantyBySerial(t *testing.T) {
 	if got.UpgradeURL != "https://example.com/upgrade" {
 		t.Errorf("UpgradeURL = %q", got.UpgradeURL)
 	}
-	if got.Purchased == nil || !got.Purchased.Time.Equal(time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC)) {
+	if got.Purchased == nil || !got.Purchased.Equal(time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC)) {
 		t.Errorf("Purchased = %v, want 2020-04-15", got.Purchased)
 	}
 	if len(got.Warranty) != 1 {

--- a/warranty_test.go
+++ b/warranty_test.go
@@ -337,6 +337,35 @@ func TestContractByID(t *testing.T) {
 	}
 }
 
+func TestContractByIDNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if _, err := c.ContractByID("X"); !errors.Is(err, ErrRequestFailed) {
+		t.Fatalf("err = %v, want ErrRequestFailed", err)
+	}
+}
+
+func TestContractByIDEscapesPath(t *testing.T) {
+	var rawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawPath = r.URL.EscapedPath()
+		_, _ = io.WriteString(w, `{"ID":"CT/01"}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if _, err := c.ContractByID("CT/01"); err != nil {
+		t.Fatalf("ContractByID: %v", err)
+	}
+	if rawPath != "/Contract/CT%2F01" {
+		t.Errorf("escaped path = %q, want /Contract/CT%%2F01", rawPath)
+	}
+}
+
 func TestContractByIDEmpty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, `{}`)

--- a/warranty_test.go
+++ b/warranty_test.go
@@ -4,24 +4,10 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 )
-
-// newTestClient wires a Client at the given httptest.Server.
-func newTestClient(t *testing.T, srv *httptest.Server) *Client {
-	t.Helper()
-	c, err := NewClient(
-		SetClientID("test-client-id"),
-		SetHttpClient(srv.Client()),
-		SetBaseURL(srv.URL),
-	)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	return c
-}
 
 func TestWarrantyBySerial(t *testing.T) {
 	const body = `{
@@ -34,346 +20,206 @@ func TestWarrantyBySerial(t *testing.T) {
 		"UpgradeUrl": "https://example.com/upgrade",
 		"Warranty": [
 			{
-				"ID": "3Y-DEPOT",
-				"Name": "3 Year Depot",
-				"Description": "Depot warranty",
+				"ID": "3Y-DEPOT", "Name": "3 Year Depot", "Description": "Depot warranty",
 				"Type": "BASE",
-				"Start": "2020-04-20T00:00:00Z",
-				"End": "2023-04-20T00:00:00Z"
+				"Start": "2020-04-20T00:00:00Z", "End": "2023-04-20T00:00:00Z"
 			}
 		],
 		"Contract": []
 	}`
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("method = %q, want POST", r.Method)
-		}
-		if r.URL.Path != "/warranty" {
-			t.Errorf("path = %q, want /warranty", r.URL.Path)
-		}
-		if got := r.Header.Get("ClientID"); got != "test-client-id" {
-			t.Errorf("ClientID header = %q, want test-client-id", got)
-		}
-		if got := r.Header.Get("Content-Type"); got != contentTypeForm {
-			t.Errorf("Content-Type = %q, want %q", got, contentTypeForm)
-		}
-		// http.NewRequest with *strings.Reader auto-sets ContentLength; the
-		// body byte count must match.
-		bodyLen := r.ContentLength
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
-		}
-		if int64(len(r.PostForm.Encode())) != bodyLen {
-			t.Errorf("ContentLength = %d, form bytes = %d", bodyLen, len(r.PostForm.Encode()))
-		}
-		if got := r.PostForm.Get("Serial"); got != "MP1ABCDE" {
-			t.Errorf("Serial form value = %q, want MP1ABCDE", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, body)
-	}))
-	defer srv.Close()
-
+	var seen http.Request
+	srv := newTestServer(t, respondJSON(&seen, body))
 	c := newTestClient(t, srv)
+
 	got, err := c.WarrantyBySerial("MP1ABCDE")
 	if err != nil {
 		t.Fatalf("WarrantyBySerial: %v", err)
 	}
-	if got.Serial != "MP1ABCDE" {
-		t.Errorf("Serial = %q, want MP1ABCDE", got.Serial)
+
+	// Request shape.
+	if seen.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", seen.Method)
 	}
-	if !got.InWarranty {
-		t.Error("InWarranty = false, want true")
+	if seen.URL.Path != "/warranty" {
+		t.Errorf("path = %q, want /warranty", seen.URL.Path)
 	}
-	if got.Country != "DE" {
-		t.Errorf("Country = %q, want DE", got.Country)
+	if h := seen.Header.Get("ClientID"); h != "test-client-id" {
+		t.Errorf("ClientID = %q, want test-client-id", h)
 	}
-	if got.UpgradeURL != "https://example.com/upgrade" {
-		t.Errorf("UpgradeURL = %q", got.UpgradeURL)
+	if h := seen.Header.Get("Content-Type"); h != contentTypeForm {
+		t.Errorf("Content-Type = %q, want %q", h, contentTypeForm)
 	}
-	if got.Purchased == nil || !got.Purchased.Equal(time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC)) {
-		t.Errorf("Purchased = %v, want 2020-04-15", got.Purchased)
+	if s := seen.PostForm.Get("Serial"); s != "MP1ABCDE" {
+		t.Errorf("Serial form = %q, want MP1ABCDE", s)
 	}
-	if len(got.Warranty) != 1 {
-		t.Fatalf("len(Warranty) = %d, want 1", len(got.Warranty))
+	if int64(len(seen.PostForm.Encode())) != seen.ContentLength {
+		t.Errorf("ContentLength = %d, form bytes = %d", seen.ContentLength, len(seen.PostForm.Encode()))
 	}
-	if got.Warranty[0].Type != WarrantyTypeBase {
-		t.Errorf("Warranty[0].Type = %q, want %q", got.Warranty[0].Type, WarrantyTypeBase)
+
+	// Response decoding.
+	want := &Warranty{
+		Serial:     "MP1ABCDE",
+		Product:    "20HES03P00",
+		InWarranty: true,
+		Purchased:  &Time{time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC)},
+		Shipped:    &Time{time.Date(2020, 4, 20, 0, 0, 0, 0, time.UTC)},
+		Country:    "DE",
+		UpgradeURL: "https://example.com/upgrade",
+		Warranty: []WarrantyWarranty{{
+			ID: "3Y-DEPOT", Name: "3 Year Depot", Description: "Depot warranty",
+			Type:  WarrantyTypeBase,
+			Start: Time{time.Date(2020, 4, 20, 0, 0, 0, 0, time.UTC)},
+			End:   Time{time.Date(2023, 4, 20, 0, 0, 0, 0, time.UTC)},
+		}},
+		Contract: []WarrantyContract{},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Warranty mismatch\n got: %+v\nwant: %+v", got, want)
 	}
 }
 
-func TestWarrantyBySerialEmptyResponse(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{}`)
-	}))
-	defer srv.Close()
+func TestWarrantyBySerial_Errors(t *testing.T) {
+	t.Run("non-200 returns ErrRequestFailed", func(t *testing.T) {
+		srv := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusInternalServerError)
+		})
+		c := newTestClient(t, srv)
+		if _, err := c.WarrantyBySerial("X"); !errors.Is(err, ErrRequestFailed) {
+			t.Errorf("err = %v, want ErrRequestFailed", err)
+		}
+	})
 
-	c := newTestClient(t, srv)
-	_, err := c.WarrantyBySerial("X")
-	if !errors.Is(err, ErrInvalidResponse) {
-		t.Fatalf("err = %v, want ErrInvalidResponse", err)
-	}
-}
-
-func TestWarrantyBySerialNon200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "nope", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	_, err := c.WarrantyBySerial("X")
-	if !errors.Is(err, ErrRequestFailed) {
-		t.Fatalf("err = %v, want ErrRequestFailed", err)
-	}
+	t.Run("empty body returns ErrInvalidResponse", func(t *testing.T) {
+		srv := newTestServer(t, respondJSON(nil, `{}`))
+		c := newTestClient(t, srv)
+		if _, err := c.WarrantyBySerial("X"); !errors.Is(err, ErrInvalidResponse) {
+			t.Errorf("err = %v, want ErrInvalidResponse", err)
+		}
+	})
 }
 
 func TestWarrantiesBySerials(t *testing.T) {
-	const body = `[
-		{"Serial":"A","Product":"P1","InWarranty":true},
-		{"Serial":"B","Product":"P2","InWarranty":false}
-	]`
+	t.Run("encodes all serials", func(t *testing.T) {
+		var seen http.Request
+		srv := newTestServer(t, respondJSON(&seen, `[{"Serial":"A"},{"Serial":"B"},{"Serial":"C"}]`))
+		c := newTestClient(t, srv)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
+		got, err := c.WarrantiesBySerials([]string{"A", "B", "C"})
+		if err != nil {
+			t.Fatalf("WarrantiesBySerials: %v", err)
 		}
-		serials := r.PostForm["Serial"]
-		want := []string{"A", "B", "C"}
-		if len(serials) != len(want) {
-			t.Fatalf("Serial count = %d, want %d", len(serials), len(want))
+		if want := []string{"A", "B", "C"}; !reflect.DeepEqual(seen.PostForm["Serial"], want) {
+			t.Errorf("Serial form values = %q, want %q", seen.PostForm["Serial"], want)
 		}
-		for i, s := range want {
-			if serials[i] != s {
-				t.Errorf("Serial[%d] = %q, want %q", i, serials[i], s)
-			}
+		if len(got) != 3 {
+			t.Errorf("len = %d, want 3", len(got))
 		}
-		_, _ = io.WriteString(w, body)
-	}))
-	defer srv.Close()
+	})
 
-	c := newTestClient(t, srv)
-	got, err := c.WarrantiesBySerials([]string{"A", "B", "C"})
-	if err != nil {
-		t.Fatalf("WarrantiesBySerials: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("len = %d, want 2", len(got))
-	}
-	if got[0].Serial != "A" || got[1].Serial != "B" {
-		t.Errorf("serials = %q,%q", got[0].Serial, got[1].Serial)
-	}
-}
-
-func TestWarrantiesBySerialsTooFew(t *testing.T) {
-	c, err := NewClient(SetClientID("x"))
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	if _, err := c.WarrantiesBySerials([]string{"only-one"}); !errors.Is(err, ErrNotEnoughSerials) {
-		t.Fatalf("err = %v, want ErrNotEnoughSerials", err)
-	}
+	t.Run("rejects single serial", func(t *testing.T) {
+		c, err := NewClient(SetClientID("x"))
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		if _, err := c.WarrantiesBySerials([]string{"only-one"}); !errors.Is(err, ErrNotEnoughSerials) {
+			t.Errorf("err = %v, want ErrNotEnoughSerials", err)
+		}
+	})
 }
 
 func TestWarrantyDetailsByID(t *testing.T) {
 	const body = `{
-		"ID": "3Y-DEPOT",
-		"Name": "3 Year Depot",
-		"Description": "Depot warranty",
-		"Type": "BASE",
-		"Delivery": "DEPOT",
-		"Category": "MACHINE",
-		"Duration": "3Y"
+		"ID": "3Y-DEPOT", "Name": "3 Year Depot", "Description": "Depot warranty",
+		"Type": "BASE", "Delivery": "DEPOT", "Category": "MACHINE", "Duration": "3Y"
 	}`
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("method = %q, want GET", r.Method)
-		}
-		if r.URL.Path != "/warranty/3Y-DEPOT" {
-			t.Errorf("path = %q", r.URL.Path)
-		}
-		_, _ = io.WriteString(w, body)
-	}))
-	defer srv.Close()
-
+	var seen http.Request
+	srv := newTestServer(t, respondJSON(&seen, body))
 	c := newTestClient(t, srv)
+
 	got, err := c.WarrantyDetailsByID("3Y-DEPOT")
 	if err != nil {
 		t.Fatalf("WarrantyDetailsByID: %v", err)
 	}
-	if got.ID != "3Y-DEPOT" {
-		t.Errorf("ID = %q", got.ID)
+	if seen.Method != http.MethodGet {
+		t.Errorf("method = %q, want GET", seen.Method)
 	}
-	if got.Type != WarrantyTypeBase || got.Delivery != DeliveryDepot || got.Category != CategoryMachine {
-		t.Errorf("enums = %q/%q/%q", got.Type, got.Delivery, got.Category)
+	if seen.URL.Path != "/warranty/3Y-DEPOT" {
+		t.Errorf("path = %q, want /warranty/3Y-DEPOT", seen.URL.Path)
 	}
-}
-
-func TestWarrantyDetailsByIDEmpty(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{}`)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	if _, err := c.WarrantyDetailsByID("missing"); !errors.Is(err, ErrInvalidResponse) {
-		t.Fatalf("err = %v, want ErrInvalidResponse", err)
+	want := &WarrantyDetails{
+		ID: "3Y-DEPOT", Name: "3 Year Depot", Description: "Depot warranty",
+		Type: WarrantyTypeBase, Delivery: DeliveryDepot, Category: CategoryMachine, Duration: "3Y",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WarrantyDetails mismatch\n got: %+v\nwant: %+v", got, want)
 	}
 }
 
-func TestWarrantyDetailsByIDEscapesPath(t *testing.T) {
+func TestWarrantyDetailsByID_Errors(t *testing.T) {
+	t.Run("empty body returns ErrInvalidResponse", func(t *testing.T) {
+		srv := newTestServer(t, respondJSON(nil, `{}`))
+		c := newTestClient(t, srv)
+		if _, err := c.WarrantyDetailsByID("X"); !errors.Is(err, ErrInvalidResponse) {
+			t.Errorf("err = %v, want ErrInvalidResponse", err)
+		}
+	})
+}
+
+func TestWarrantyDetailsByID_EscapesPath(t *testing.T) {
 	var rawPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		rawPath = r.URL.EscapedPath()
 		_, _ = io.WriteString(w, `{"ID":"weird/value","Name":"x"}`)
-	}))
-	defer srv.Close()
-
+	})
 	c := newTestClient(t, srv)
+
 	if _, err := c.WarrantyDetailsByID("weird/value"); err != nil {
 		t.Fatalf("WarrantyDetailsByID: %v", err)
 	}
-	if rawPath != "/warranty/weird%2Fvalue" {
-		t.Errorf("escaped path = %q, want /warranty/weird%%2Fvalue", rawPath)
+	if want := "/warranty/weird%2Fvalue"; rawPath != want {
+		t.Errorf("escaped path = %q, want %q", rawPath, want)
 	}
 }
 
-func TestWarrantyOptionsBySerial(t *testing.T) {
-	const body = `[
-		{"ID":"5Y-ONSITE","Name":"5Y","Type":"UPGRADE","Delivery":"ON_SITE","Category":"MACHINE","Country":"US"}
-	]`
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("method = %q, want POST", r.Method)
-		}
-		if r.URL.Path != "/warrantyoption/US" {
-			t.Errorf("path = %q, want /warrantyoption/US", r.URL.Path)
-		}
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
-		}
-		if got := r.PostForm.Get("Serial"); got != "MP1ABCDE" {
-			t.Errorf("Serial = %q, want MP1ABCDE", got)
-		}
-		_, _ = io.WriteString(w, body)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	got, err := c.WarrantyOptionsBySerial("US", "MP1ABCDE")
-	if err != nil {
-		t.Fatalf("WarrantyOptionsBySerial: %v", err)
+func TestWarrantyOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		call     func(*Client) ([]WarrantyOption, error)
+		wantPath string
+		wantKey  string
+		wantVal  string
+	}{
+		{
+			name:     "by serial with country",
+			call:     func(c *Client) ([]WarrantyOption, error) { return c.WarrantyOptionsBySerial("US", "MP1ABCDE") },
+			wantPath: "/warrantyoption/US",
+			wantKey:  "Serial", wantVal: "MP1ABCDE",
+		},
+		{
+			name:     "by product without country",
+			call:     func(c *Client) ([]WarrantyOption, error) { return c.WarrantyOptionsByProduct("", "20HES03P00") },
+			wantPath: "/warrantyoption",
+			wantKey:  "Product", wantVal: "20HES03P00",
+		},
 	}
-	if len(got) != 1 || got[0].Country != "US" || got[0].Delivery != DeliveryOnSite {
-		t.Errorf("unexpected: %+v", got)
-	}
-}
 
-func TestWarrantyOptionsByProductDefaultCountry(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/warrantyoption" {
-			t.Errorf("path = %q, want /warrantyoption (no country segment)", r.URL.Path)
-		}
-		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
-		}
-		if got := r.PostForm.Get("Product"); got != "20HES03P00" {
-			t.Errorf("Product = %q", got)
-		}
-		_, _ = io.WriteString(w, `[]`)
-	}))
-	defer srv.Close()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen http.Request
+			srv := newTestServer(t, respondJSON(&seen, `[]`))
+			c := newTestClient(t, srv)
 
-	c := newTestClient(t, srv)
-	got, err := c.WarrantyOptionsByProduct("", "20HES03P00")
-	if err != nil {
-		t.Fatalf("WarrantyOptionsByProduct: %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("len = %d, want 0", len(got))
-	}
-}
-
-func TestContractByID(t *testing.T) {
-	const body = `{
-		"ID": "CT-001",
-		"Description": "Premier",
-		"Start": "2024-01-01T00:00:00Z",
-		"End": "2027-01-01T00:00:00Z",
-		"Products": [
-			{
-				"Serial": "MP1ABCDE",
-				"MachineType": "20HE",
-				"Name": "ThinkPad",
-				"Quantity": 1,
-				"Status": "ACTIVE",
-				"Start": "2024-01-01T00:00:00Z",
-				"End": "2027-01-01T00:00:00Z"
+			if _, err := tc.call(c); err != nil {
+				t.Fatalf("call: %v", err)
 			}
-		]
-	}`
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("method = %q, want GET", r.Method)
-		}
-		if r.URL.Path != "/Contract/CT-001" {
-			t.Errorf("path = %q", r.URL.Path)
-		}
-		_, _ = io.WriteString(w, body)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	got, err := c.ContractByID("CT-001")
-	if err != nil {
-		t.Fatalf("ContractByID: %v", err)
-	}
-	if got.ID != "CT-001" || len(got.Products) != 1 || got.Products[0].MachineType != "20HE" {
-		t.Errorf("unexpected: %+v", got)
-	}
-}
-
-func TestContractByIDNon200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "nope", http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	if _, err := c.ContractByID("X"); !errors.Is(err, ErrRequestFailed) {
-		t.Fatalf("err = %v, want ErrRequestFailed", err)
-	}
-}
-
-func TestContractByIDEscapesPath(t *testing.T) {
-	var rawPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rawPath = r.URL.EscapedPath()
-		_, _ = io.WriteString(w, `{"ID":"CT/01"}`)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	if _, err := c.ContractByID("CT/01"); err != nil {
-		t.Fatalf("ContractByID: %v", err)
-	}
-	if rawPath != "/Contract/CT%2F01" {
-		t.Errorf("escaped path = %q, want /Contract/CT%%2F01", rawPath)
-	}
-}
-
-func TestContractByIDEmpty(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{}`)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t, srv)
-	if _, err := c.ContractByID("missing"); !errors.Is(err, ErrInvalidResponse) {
-		t.Fatalf("err = %v, want ErrInvalidResponse", err)
+			if seen.URL.Path != tc.wantPath {
+				t.Errorf("path = %q, want %q", seen.URL.Path, tc.wantPath)
+			}
+			if got := seen.PostForm.Get(tc.wantKey); got != tc.wantVal {
+				t.Errorf("%s form = %q, want %q", tc.wantKey, got, tc.wantVal)
+			}
+		})
 	}
 }

--- a/warranty_test.go
+++ b/warranty_test.go
@@ -1,0 +1,350 @@
+package lenovo
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTestClient wires a Client at the given httptest.Server.
+func newTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	c, err := NewClient(
+		SetClientID("test-client-id"),
+		SetHttpClient(srv.Client()),
+		SetBaseURL(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestWarrantyBySerial(t *testing.T) {
+	const body = `{
+		"Serial": "MP1ABCDE",
+		"Product": "20HES03P00",
+		"InWarranty": true,
+		"Purchased": "2020-04-15T00:00:00Z",
+		"Shipped": "2020-04-20T00:00:00Z",
+		"Country": "DE",
+		"UpgradeUrl": "https://example.com/upgrade",
+		"Warranty": [
+			{
+				"ID": "3Y-DEPOT",
+				"Name": "3 Year Depot",
+				"Description": "Depot warranty",
+				"Type": "BASE",
+				"Start": "2020-04-20T00:00:00Z",
+				"End": "2023-04-20T00:00:00Z"
+			}
+		],
+		"Contract": []
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/warranty" {
+			t.Errorf("path = %q, want /warranty", r.URL.Path)
+		}
+		if got := r.Header.Get("ClientID"); got != "test-client-id" {
+			t.Errorf("ClientID header = %q, want test-client-id", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != contentTypeForm {
+			t.Errorf("Content-Type = %q, want %q", got, contentTypeForm)
+		}
+		// http.NewRequest with *strings.Reader auto-sets ContentLength; the
+		// body byte count must match.
+		bodyLen := r.ContentLength
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if int64(len(r.PostForm.Encode())) != bodyLen {
+			t.Errorf("ContentLength = %d, form bytes = %d", bodyLen, len(r.PostForm.Encode()))
+		}
+		if got := r.PostForm.Get("Serial"); got != "MP1ABCDE" {
+			t.Errorf("Serial form value = %q, want MP1ABCDE", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.WarrantyBySerial("MP1ABCDE")
+	if err != nil {
+		t.Fatalf("WarrantyBySerial: %v", err)
+	}
+	if got.Serial != "MP1ABCDE" {
+		t.Errorf("Serial = %q, want MP1ABCDE", got.Serial)
+	}
+	if !got.InWarranty {
+		t.Error("InWarranty = false, want true")
+	}
+	if got.Country != "DE" {
+		t.Errorf("Country = %q, want DE", got.Country)
+	}
+	if got.UpgradeURL != "https://example.com/upgrade" {
+		t.Errorf("UpgradeURL = %q", got.UpgradeURL)
+	}
+	if got.Purchased == nil || !got.Purchased.Time.Equal(time.Date(2020, 4, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("Purchased = %v, want 2020-04-15", got.Purchased)
+	}
+	if len(got.Warranty) != 1 {
+		t.Fatalf("len(Warranty) = %d, want 1", len(got.Warranty))
+	}
+	if got.Warranty[0].Type != WarrantyTypeBase {
+		t.Errorf("Warranty[0].Type = %q, want %q", got.Warranty[0].Type, WarrantyTypeBase)
+	}
+}
+
+func TestWarrantyBySerialEmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WarrantyBySerial("X")
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Fatalf("err = %v, want ErrInvalidResponse", err)
+	}
+}
+
+func TestWarrantyBySerialNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.WarrantyBySerial("X")
+	if !errors.Is(err, ErrRequestFailed) {
+		t.Fatalf("err = %v, want ErrRequestFailed", err)
+	}
+}
+
+func TestWarrantiesBySerials(t *testing.T) {
+	const body = `[
+		{"Serial":"A","Product":"P1","InWarranty":true},
+		{"Serial":"B","Product":"P2","InWarranty":false}
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		serials := r.PostForm["Serial"]
+		want := []string{"A", "B", "C"}
+		if len(serials) != len(want) {
+			t.Fatalf("Serial count = %d, want %d", len(serials), len(want))
+		}
+		for i, s := range want {
+			if serials[i] != s {
+				t.Errorf("Serial[%d] = %q, want %q", i, serials[i], s)
+			}
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.WarrantiesBySerials([]string{"A", "B", "C"})
+	if err != nil {
+		t.Fatalf("WarrantiesBySerials: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Serial != "A" || got[1].Serial != "B" {
+		t.Errorf("serials = %q,%q", got[0].Serial, got[1].Serial)
+	}
+}
+
+func TestWarrantiesBySerialsTooFew(t *testing.T) {
+	c, err := NewClient(SetClientID("x"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := c.WarrantiesBySerials([]string{"only-one"}); !errors.Is(err, ErrNotEnoughSerials) {
+		t.Fatalf("err = %v, want ErrNotEnoughSerials", err)
+	}
+}
+
+func TestWarrantyDetailsByID(t *testing.T) {
+	const body = `{
+		"ID": "3Y-DEPOT",
+		"Name": "3 Year Depot",
+		"Description": "Depot warranty",
+		"Type": "BASE",
+		"Delivery": "DEPOT",
+		"Category": "MACHINE",
+		"Duration": "3Y"
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/warranty/3Y-DEPOT" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.WarrantyDetailsByID("3Y-DEPOT")
+	if err != nil {
+		t.Fatalf("WarrantyDetailsByID: %v", err)
+	}
+	if got.ID != "3Y-DEPOT" {
+		t.Errorf("ID = %q", got.ID)
+	}
+	if got.Type != WarrantyTypeBase || got.Delivery != DeliveryDepot || got.Category != CategoryMachine {
+		t.Errorf("enums = %q/%q/%q", got.Type, got.Delivery, got.Category)
+	}
+}
+
+func TestWarrantyDetailsByIDEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if _, err := c.WarrantyDetailsByID("missing"); !errors.Is(err, ErrInvalidResponse) {
+		t.Fatalf("err = %v, want ErrInvalidResponse", err)
+	}
+}
+
+func TestWarrantyDetailsByIDEscapesPath(t *testing.T) {
+	var rawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawPath = r.URL.EscapedPath()
+		_, _ = io.WriteString(w, `{"ID":"weird/value","Name":"x"}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if _, err := c.WarrantyDetailsByID("weird/value"); err != nil {
+		t.Fatalf("WarrantyDetailsByID: %v", err)
+	}
+	if rawPath != "/warranty/weird%2Fvalue" {
+		t.Errorf("escaped path = %q, want /warranty/weird%%2Fvalue", rawPath)
+	}
+}
+
+func TestWarrantyOptionsBySerial(t *testing.T) {
+	const body = `[
+		{"ID":"5Y-ONSITE","Name":"5Y","Type":"UPGRADE","Delivery":"ON_SITE","Category":"MACHINE","Country":"US"}
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/warrantyoption/US" {
+			t.Errorf("path = %q, want /warrantyoption/US", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.PostForm.Get("Serial"); got != "MP1ABCDE" {
+			t.Errorf("Serial = %q, want MP1ABCDE", got)
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.WarrantyOptionsBySerial("US", "MP1ABCDE")
+	if err != nil {
+		t.Fatalf("WarrantyOptionsBySerial: %v", err)
+	}
+	if len(got) != 1 || got[0].Country != "US" || got[0].Delivery != DeliveryOnSite {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestWarrantyOptionsByProductDefaultCountry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/warrantyoption" {
+			t.Errorf("path = %q, want /warrantyoption (no country segment)", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.PostForm.Get("Product"); got != "20HES03P00" {
+			t.Errorf("Product = %q", got)
+		}
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.WarrantyOptionsByProduct("", "20HES03P00")
+	if err != nil {
+		t.Fatalf("WarrantyOptionsByProduct: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+}
+
+func TestContractByID(t *testing.T) {
+	const body = `{
+		"ID": "CT-001",
+		"Description": "Premier",
+		"Start": "2024-01-01T00:00:00Z",
+		"End": "2027-01-01T00:00:00Z",
+		"Products": [
+			{
+				"Serial": "MP1ABCDE",
+				"MachineType": "20HE",
+				"Name": "ThinkPad",
+				"Quantity": 1,
+				"Status": "ACTIVE",
+				"Start": "2024-01-01T00:00:00Z",
+				"End": "2027-01-01T00:00:00Z"
+			}
+		]
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/Contract/CT-001" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	got, err := c.ContractByID("CT-001")
+	if err != nil {
+		t.Fatalf("ContractByID: %v", err)
+	}
+	if got.ID != "CT-001" || len(got.Products) != 1 || got.Products[0].MachineType != "20HE" {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+func TestContractByIDEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if _, err := c.ContractByID("missing"); !errors.Is(err, ErrInvalidResponse) {
+		t.Fatalf("err = %v, want ErrInvalidResponse", err)
+	}
+}


### PR DESCRIPTION
## Summary
Extends the Lenovo SDK to cover the remaining endpoints documented at https://supportapi.lenovo.com/documentation/Warranty.html.

- `WarrantyDetailsByID(id)` — `GET /v2.5/warranty/{ID}` (SDF code lookup), returns `WarrantyDetails` with `Type`, `Delivery`, `Category`, `Duration`.
- `ContractByID(id)` — `GET /v2.5/Contract/{ID}`, returns `Contract` with covered `Products` (including `MachineType`, which the product-warranty endpoint does not surface).
- `WarrantyOptionsBySerial(country, serial)` / `WarrantyOptionsByProduct(country, product)` — `POST /v2.5/warrantyoption/{country-code}`. `country` may be empty.
- Exposes documented enum values for warranty `Type`, `Delivery`, and `Category` as constants.

The existing `WarrantyBySerial` / `WarrantiesBySerials` already covered endpoint #1 and are unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Smoke-test against the live API with a real `ClientID` (requires credentials)