### PR TITLE
feat: expose Delivery, Category, Status, SLA, EntitlementCode on WarrantyWarranty

### DIFF
--- a/warranty.go
+++ b/warranty.go
@@ -65,12 +65,17 @@ type Warranty struct {
 }
 
 type WarrantyWarranty struct {
-	ID          string
-	Name        string
-	Description string
-	Type        string
-	Start       Time
-	End         Time
+	ID              string
+	Name            string
+	Description     string
+	Type            string
+	Delivery        string
+	Category        string
+	Status          string
+	SLA             string
+	EntitlementCode string
+	Start           Time
+	End             Time
 }
 
 type WarrantyContract struct {

--- a/warranty_test.go
+++ b/warranty_test.go
@@ -22,6 +22,11 @@ func TestWarrantyBySerial(t *testing.T) {
 			{
 				"ID": "3Y-DEPOT", "Name": "3 Year Depot", "Description": "Depot warranty",
 				"Type": "BASE",
+				"Delivery": "DEPOT",
+				"Category": "MACHINE",
+				"Status": "Active",
+				"SLA": "NBD",
+				"EntitlementCode": "EC-1",
 				"Start": "2020-04-20T00:00:00Z", "End": "2023-04-20T00:00:00Z"
 			}
 		],
@@ -68,9 +73,14 @@ func TestWarrantyBySerial(t *testing.T) {
 		UpgradeURL: "https://example.com/upgrade",
 		Warranty: []WarrantyWarranty{{
 			ID: "3Y-DEPOT", Name: "3 Year Depot", Description: "Depot warranty",
-			Type:  WarrantyTypeBase,
-			Start: Time{time.Date(2020, 4, 20, 0, 0, 0, 0, time.UTC)},
-			End:   Time{time.Date(2023, 4, 20, 0, 0, 0, 0, time.UTC)},
+			Type:            WarrantyTypeBase,
+			Delivery:        DeliveryDepot,
+			Category:        CategoryMachine,
+			Status:          "Active",
+			SLA:             "NBD",
+			EntitlementCode: "EC-1",
+			Start:           Time{time.Date(2020, 4, 20, 0, 0, 0, 0, time.UTC)},
+			End:             Time{time.Date(2023, 4, 20, 0, 0, 0, 0, time.UTC)},
 		}},
 		Contract: []WarrantyContract{},
 	}


### PR DESCRIPTION
## What & Why

The Lenovo eSupport `/warranty` endpoint returns five fields per `Warranty[]` entry that the SDK previously dropped at decode time: `Delivery`, `Category`, `Status`, `SLA`, `EntitlementCode`.

`WarrantyContract` already exposes `SLA`, `EntitlementCode`, `Status`. `WarrantyDetails` already exposes `Delivery`, `Category`. The package even defines `DeliveryDepot`, `CategoryMachine`, and the rest of the constants for fields it never exposed. This patch closes that gap.

## Changes

- `warranty.go` — five string fields added to `WarrantyWarranty`, ordered to match the upstream doc
- `warranty_test.go` — decode fixture extended to cover the new fields

No new constants; backwards-compatible (zero values when absent from the response).