### PR TITLE
fix: accept timestamps without timezone offset

### DIFF
--- a/time.go
+++ b/time.go
@@ -13,12 +13,15 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		return nil
 	}
-	if string(data) == "\"0001-01-01T00:00:00\"" {
-		return nil
-	}
 
 	// Fractional seconds are handled implicitly by Parse.
 	var err error
 	t.Time, err = time.Parse(`"`+time.RFC3339+`"`, string(data))
+	if err != nil {
+		// The eSupport API also returns timestamps without a timezone
+		// offset (e.g. "2026-05-06T00:00:00"); interpret those as UTC.
+		// This also covers the "0001-01-01T00:00:00" zero sentinel.
+		t.Time, err = time.Parse(`"2006-01-02T15:04:05"`, string(data))
+	}
 	return err
 }

--- a/time_test.go
+++ b/time_test.go
@@ -17,6 +17,9 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		{"RFC3339 UTC", `"2024-06-15T12:30:00Z"`, time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)},
 		{"RFC3339 offset", `"2024-06-15T14:30:00+02:00"`,
 			time.Date(2024, 6, 15, 14, 30, 0, 0, time.FixedZone("", 2*60*60))},
+		{"no timezone", `"2026-05-06T00:00:00"`, time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)},
+		{"no timezone fractional", `"2026-05-06T10:20:30.5"`,
+			time.Date(2026, 5, 6, 10, 20, 30, 500000000, time.UTC)},
 	}
 
 	for _, tc := range cases {
@@ -27,6 +30,9 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 			}
 			if !got.Equal(tc.want) {
 				t.Errorf("Time = %v, want %v", got, tc.want)
+			}
+			if got.IsZero() != tc.want.IsZero() {
+				t.Errorf("IsZero() = %v, want %v", got.IsZero(), tc.want.IsZero())
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

The asset-coverage sync in negsoft-api fails when querying Lenovo warranties:

```
query lenovo warranties: parsing time "\"2026-05-06T00:00:00\"" as "\"2006-01-02T15:04:05Z07:00\"": cannot parse "\"" as "Z07:00"
```

`Time.UnmarshalJSON` only accepts RFC3339, but the eSupport API returns timestamps without a timezone offset (e.g. `"2026-05-06T00:00:00"`). The existing `"0001-01-01T00:00:00"` zero-sentinel special case was already evidence of this wire format.

## Fix

When RFC3339 parsing fails, fall back to parsing the zone-less layout `2006-01-02T15:04:05` as UTC. Fractional seconds are still handled implicitly by `time.Parse` in both layouts.

The fallback subsumes the zero-sentinel special case (`"0001-01-01T00:00:00"` now parses naturally to the zero time, and `IsZero()` still reports true — the test asserts this, since negsoft-api filters entries on `End.IsZero()`).

## Testing

```
go vet ./... && go test ./...
ok  	github.com/enthus-golang/lenovo	0.564s
```